### PR TITLE
Update compileSdkVersion from 31 to 36

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
`compileSdkVersion 31` causes build failures in apps that include other plugins
with newer androidx dependencies. Gradle's `checkAarMetadata` task requires all
modules in the build to declare a `compileSdkVersion` high enough to satisfy the
constraints of whatever dependency versions were resolved — even for transitive
dependencies that `media_scanner` itself does not use.

Bumping to 36 fixes this. No source changes are needed since the plugin only
uses APIs already available.
